### PR TITLE
fix: repairs multipacket requests

### DIFF
--- a/src/htstub.erl
+++ b/src/htstub.erl
@@ -453,8 +453,8 @@ parse_body(ConnectedSocket, Body, Path, Protocol, Method, PHeaders) ->
 
 parse_body(ConnectedSocket, Body, Path, Protocol, Method, PHeaders, CurrentLength, BodyLength) when CurrentLength < BodyLength ->
 
-    {ok,NewRecv} = gen_tcp:recv(ConnectedSocket, 0),
-    parse_body(ConnectedSocket, Body ++ NewRecv, Path, Protocol, Method, PHeaders, CurrentLength+length(NewRecv), BodyLength);
+    {ok, NewRecv} = gen_tcp:recv(ConnectedSocket, 0),
+    parse_body(ConnectedSocket, [Body | NewRecv], Path, Protocol, Method, PHeaders, CurrentLength+size(NewRecv), BodyLength);
 
 
 
@@ -512,7 +512,7 @@ body_reformat(Body, Path, Protocol, Method, PHeaders, BodyLength) ->
             parsed=parse_uri(PPath),
             method=Method,
             pheaders=PHeaders,
-            body=Body,
+            body=iolist_to_binary(Body),
             body_length=BodyLength
           }
     }.
@@ -919,7 +919,7 @@ rest(Config) when is_record(Config, htstub_config) ->
 
 
 
-rest(RestHandler, Port) when is_function(RestHandler), is_integer(Port) ->
+rest(RestHandler, Port) when is_function(RestHandler, 3), is_integer(Port) ->
 
     serve(restify(RestHandler), Port).
 


### PR DESCRIPTION
several incorrect semantics were discovered in the parse_body fun which
handles the case when the current length is incomplete.

1) the ++ operator was called to try to stitch together binaries.  This
was changed to the cons operator to make it an iolist.

2) the length() kernel function was called to try to measure the
length of the binary, this was changed to size()

3) the final piece putting together the htstub_request was changed to
convert the streamed body from iolist into a proper binary.  (this
might not actually be performant but whatever).

As a bonus, an extra guard was put in preventing idiots like me from
doing a stupid thing with htstub:rest