### PR TITLE
Update htstub.erl

### DIFF
--- a/src/htstub.erl
+++ b/src/htstub.erl
@@ -403,6 +403,12 @@ return_result(ConnectedSocket, {Status, Response}) when is_integer(Status), is_l
 
 
 
+return_result(ConnectedSocket, {Status, Response}) when is_integer(Status), is_binary(Response) ->
+
+    return_result(ConnectedSocket, {Status, binary_to_list(Response)})
+
+
+
 
 return_result(ConnectedSocket, {Status, Headers, Response}) ->
 


### PR DESCRIPTION
fixes it so that semantics for rest are friendly for those of us fools who use binaries instead of charlists